### PR TITLE
allow for unconventional mime types for jpg and tif

### DIFF
--- a/loris/constants.py
+++ b/loris/constants.py
@@ -16,9 +16,11 @@ __formats = (
     ('gif','image/gif'),
     ('jp2','image/jp2'),
     ('jpg','image/jpeg'),
+    ('jpg','image/jpg'),
     ('pdf','application/pdf'),
     ('png','image/png'),
     ('tif','image/tiff'),
+    ('tif','image/tif'),
     ('webp','image/webp'),
 )
 


### PR DESCRIPTION
Our source system has some mime types slightly off.  In order for Loris to identify them, we need to add them to the list of formats.